### PR TITLE
Add comparison with GitHub Spec Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Interaction memory captures distilled insights from conversations and actions so
 - Keep next steps in the TODO sections, not here. Start inline in README under a “Learnings” subsection; extract to `interaction-log.md` only when it grows.
 
 ## TODO – Lead Agent
-- Deep research: other frameworks similar to the one that is described here
+- Deep research: other frameworks similar to the one that is described here (tracking in `related-frameworks.md` and `comparisons/github-spec-kit.md`)
 - Research memory approaches (Claude Flow and others) and propose a simple initial method here (maybe alternative to our approach with "Decision Notes" and "Learnings" in readme)
 
 ## TODO – Human

--- a/comparisons/github-spec-kit.md
+++ b/comparisons/github-spec-kit.md
@@ -1,0 +1,24 @@
+# Comparison: Idea Execution Framework vs. GitHub Spec Kit
+
+## Overview of GitHub Spec Kit
+- GitHub's Spec Kit is a documentation-first toolkit for crafting product and engineering specifications.
+- It centers on markdown templates (e.g., PR/issue templates and a `spec-template.md`) that walk teams through background, problem, goals, non-goals, proposed solution, metrics, and rollout considerations.
+- The repository provides guidance on spec review workflows inside GitHub, encouraging collaborative iteration through pull requests before implementation begins.
+- Spec Kit presumes work happens in GitHub, but focuses on planning artifacts rather than storing execution state.
+
+## Overlapping Intentions
+- Both frameworks emphasize clarity before execution: they capture context, requirements, and rationale in human-readable markdown.
+- Each encourages collaborative workflows inside GitHub with version-controlled artifacts so decisions are auditable.
+- Both default to lightweight tooling—markdown files, issues, and pull requests—rather than heavyweight orchestration platforms.
+
+## Key Differences
+- **Scope of lifecycle**: Spec Kit concentrates on pre-implementation planning (writing and reviewing specs). The Idea Execution Framework spans the full cycle—from clarifying the idea to planning, execution, and capturing learnings in the repo.
+- **Primary artifacts**: Spec Kit revolves around a single spec document shepherded through review. The Idea Execution Framework treats the entire repository as the "blackboard," mixing specs, plans, decision logs, learnings, and produced assets.
+- **Role model**: Spec Kit presumes a human team collaborating directly. The Idea Execution Framework introduces an explicit Lead Agent (L1) role coordinating with the human and optionally delegating to specialized agents.
+- **Memory & state**: Spec Kit expects project memory to live in the spec and GitHub discussions. The Idea Execution Framework formalizes repo-based memory (decision notes, learnings, TODOs) to support autonomous agent execution without external state stores.
+- **Automation posture**: Spec Kit is human-centric and doc-driven. The Idea Execution Framework is automation-friendly, aiming to minimize human involvement over time while keeping the repo transparent.
+
+## Complementary Usage
+- Use Spec Kit-style documents during Phase A/B of the Idea Execution Framework when a richer product spec is required; store the spec inside the repo alongside decision notes.
+- Combine Spec Kit's review rituals with the Idea Execution Framework's continuous execution logs to maintain rigor without losing velocity.
+- Treat Spec Kit templates as optional plug-ins: import them when stakeholders need formal approval processes, but keep the execution framework lightweight for day-to-day agent work.

--- a/related-frameworks.md
+++ b/related-frameworks.md
@@ -10,6 +10,7 @@ A quick map of nearby ecosystems and how they differ from this README-first, git
 - AutoGPT (Platform) – build/deploy/manage continuous agents with UI, blocks, marketplace. Powerful, platform-centric; beyond our lightweight goals. https://github.com/Significant-Gravitas/AutoGPT
 - OpenHands (ex-OpenDevin) – full developer agent platform (terminal, files, browser). Great for coding automation; heavier runtime than our README-first pilot. https://github.com/All-Hands-AI/OpenHands
 - GPT-Engineer – prompt-to-code CLI; simple, repo-oriented but single-agent. We share the repo-first ethos without the CLI lock-in. https://github.com/AntonOsika/gpt-engineer
+- GitHub Spec Kit – spec authoring templates and review rituals for feature planning. Valuable for richer design docs, but focuses on pre-execution specs rather than repo-as-blackboard execution. https://github.com/github/spec-kit
 
 Where this framework fits
 - Bias to simplicity: git repo is the blackboard, plan, and memory; agents publish decisions and next steps into files.


### PR DESCRIPTION
## Summary
- add a dedicated comparison note covering GitHub's Spec Kit alongside the Idea Execution Framework
- reference the comparison from the lead agent TODOs and include Spec Kit in the related frameworks list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da56a535c4833281c82a15d2e0cf7d